### PR TITLE
Add watcher for  prop updates

### DIFF
--- a/vue-medium-editor.js
+++ b/vue-medium-editor.js
@@ -47,6 +47,16 @@ export default {
 
   beforeDestroy (evt) {
     this.$root.mediumEditor.removeElements(this.$refs.element)
-  }
+  },
 
+  watch: {
+    text() {
+      if (this.text === this.$refs.element.innerHTML) {
+        // if the change is done by this same component, do not update the contents to prevent
+        // caret from resetting to the beginning of the editor
+        return;
+      }
+      this.$refs.element.innerHTML = this.text
+    }
+  }
 }


### PR DESCRIPTION
Adding the ability to update the editor content when the prop is updated from outside. I don't have a solution for the caret being reset to the beginning of the edotr content, but still think this is a handy feature or even a bug fix - I spent a substantial amount of time trying to figure out why my Vue view did not update when the data was updated.