### PR TITLE
"reuse" prop to toggle between sharing the MediumEditor instance or creating a new one

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,20 @@ new Vue {
 <medium-editor :text='myText' :options='options' custom-tag='h2' v-on:edit='applyTextEdit'>
 ```
 
+### Reusing the MediumEditor instance
+
+By default the component will reuse a single MediumEditor instance within the same instance of Vue.
+
+The configuration options for the editor are then set by the first component instance and shared across any subsequent instances.
+
+If you need to have multiple instances of the editor with different configuration options, you can use the `reuse-medium-editor-instance` prop:
+
+```
+# index.html
+<medium-editor :text='myText' :options='options' :reuse-medium-editor-instance="false">
+<medium-editor :text='myOtherText' :options='differentOptions' :reuse-medium-editor-instance="false">
+```
+
 > Full usage example at [github.com/FranzSkuffka/vue-medium-editor/tree/gh-pages](https://github.com/FranzSkuffka/vue-medium-editor/tree/gh-pages)
 
 A list of available options can be found in the [documentation of MediumEditor](https://github.com/yabwe/medium-editor#core-options).


### PR DESCRIPTION
Added reuse prop to toggle whether component will attempt to use a single MediumEditor component in a single Vue instance, or if it will create a separate one.
---

I was attempting to use this component within a Vue instance that included 3 editors, two of which shared the same options, but the third had completely different ones. When the code reuses the single MediumEditor instance, the options are set by the very first use case and can't be then changed.

This new prop lets the user decide if they want to reuse the instance, or create a new one.
