### PR TITLE
Add MediumEditor reference to the component for external use

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,19 @@ Optionally you may use the standalone builds from `dist` which have medium-edito
 
 Make sure you include the required [CSS](https://github.com/yabwe/medium-editor/tree/master/dist/css).
 
+### Custom buttons and extensions
+To create extensions for the MediumEditor you will need the original MediumEditor object, which
+you can get like this:
+
+```javascript
+var HighlightButton = VueMediumEditor.MediumEditor.Extension.extend({
+    // ...
+});
+```
+
+See [Extensions](https://github.com/yabwe/medium-editor/tree/master/src/js/extensions)
+section of the MediumEditor's wiki for details.
+
 ## Bundling & Minification
 
 To generate the standalone bundle

--- a/vue-medium-editor.js
+++ b/vue-medium-editor.js
@@ -82,5 +82,7 @@ export default {
       }
       this.$refs.element.innerHTML = this.text
     }
-  }
+  },
+
+  MediumEditor
 }


### PR DESCRIPTION
I have tried to add a custom button and could not find a way to get access to MediumEditor itself. Sorted the issue by adding the reference to the VueMediumEditor object.

Just sharing my solution, let me know if there is a better way to reslve this.