### PR TITLE
Added method to trigger blur event on medium editor element

### DIFF
--- a/vue-medium-editor.js
+++ b/vue-medium-editor.js
@@ -67,5 +67,10 @@ export default {
       }
     }
   },
+  methods: {
+    blur () {
+      this.api.trigger('blur', new Event('blur'), this.$refs.element)
+    }
+  },
   MediumEditor
 }


### PR DESCRIPTION
Medium editor handles placeholders a little funky (due to relying on content editable elements which don't have proper support for placeholders).

When/if you have vue-medium-editor components being rendered in a loop, even with "key" elements, there are visual artifacts from left over placeholders.

Triggering the blur event forces medium editor to re-evaluate the placeholders (amongst other things) resulting in their removal if/when they are no longer necessary.