### PR TITLE
Integrate more nicely into existing webpack projects

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vue2-medium-editor",
   "version": "1.1.6",
   "description": "A VueJS plugin for medium-editor",
-  "main": "dist/vueMediumEditor.js",
+  "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "clean": "rm -rf dist",

--- a/package.json
+++ b/package.json
@@ -28,14 +28,14 @@
   },
   "homepage": "https://github.com/FranzSkuffka/vue-medium-editor#readme",
   "dependencies": {
-    "babel-loader": "^7.0.0",
-    "babili": "^0.1.2",
-    "medium-editor": "^5.22.1",
-    "uglifyjs-webpack-plugin": "^0.4.3",
-    "webpack": "^2.6.1"
+    "medium-editor": "^5.22.1"
   },
   "devDependencies": {
+    "babel-loader": "^7.0.0",
     "babel-preset-es2015": "^6.18.0",
-    "babelify": "^7.3.0"
+    "babelify": "^7.3.0",
+    "babili": "^0.1.2",
+    "uglifyjs-webpack-plugin": "^0.4.3",
+    "webpack": "^2.6.1"
   }
 }


### PR DESCRIPTION
I understand that in its core, this component simply uses some `import` statements. And for people without support for them it offers an already compiled file in the `dist/` directory. So, why not move all the dependencies merely used for building the file to `"devDependencies"` and just keep `"medium-editor": "^5.22.1"` in `"dependencies"`, and actually use `index.js` as entry point?

This way, already existing webpack projects (like the new vue cli 3) can take care of bundling and minifying themselves.