### PR TITLE
Adjust the options watcher to be a deep watcher

### DIFF
--- a/example/src/App.vue
+++ b/example/src/App.vue
@@ -6,6 +6,7 @@
       :text='text'
       :options='options'
       v-on:edit='applyTextEdit'
+      @editorCreated="handleEditorCreated"
       custom-tag='pre'/>
 
     <h2>Result</h2>
@@ -23,7 +24,7 @@
     <input type='checkbox' v-model='show'>
     <h2>As Text input</h2>
     <input type='text' v-model='text'>
-    </br>
+    <br/>
   </div>
 </template>
 
@@ -70,6 +71,13 @@ export default {
         console.log(ev.event.target.innerHTML)
         this.text = ev.event.target.innerHTML
       }
+    },
+    handleEditorCreated(editor) {
+      /**
+       * write what you want here after the editor has been initalised but don't update the options here
+       * without an if condition as it'll cause an infinite loop because the watcher will recreate
+       * medium editor instane
+       */
     }
   },
   components: {MediumEditor}

--- a/interactive.js
+++ b/interactive.js
@@ -58,9 +58,12 @@ export default {
      * We only tear down the editor, if the options actually changed.
      * See: https://github.com/yabwe/medium-editor/issues/1129
      */
-    options (newOptions) {
-      this.tearDown()
-      this.createAndSubscribe()
+    options: {
+      handler(newOptions) {
+        this.tearDown()
+        this.createAndSubscribe()
+      },
+      deep: true
     }
   },
   MediumEditor


### PR DESCRIPTION
Adjust the options watcher to be a deep watcher to properly execute when options change.

This PR allows proper execution of options watcher but that watcher destroys and recreates the instance causing potential infinite loops in any code inside ```editorCreated``` event handler.

we need to think of a better way to handle this, I'd be happy to hear your ideas and would implement them in this PR as well if I could.